### PR TITLE
Async requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react-redux": "^5.0.1",
     "react-router": "^3.0.0",
     "react-router-bootstrap": "^0.23.1",
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "redux-thunk": "^2.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -35,10 +35,12 @@ export const changeTerminalInputText = (text) => ({
     text: text,
 });
 
-export const submitTerminalInputText = (text) => ({
+export const submitTerminalInputText = (text, response, status) => ({
     type: ActionTypes.SUBMIT_TERMINAL_INPUT_TEXT,
+    response: response,
+    status: status,
     text: text,
-})
+});
 
 export const createBranch = (branchName) => ({
     type: ActionTypes.CREATE_BRANCH,

--- a/src/actions/asyncActions.js
+++ b/src/actions/asyncActions.js
@@ -1,0 +1,12 @@
+import { submitTerminalInputText } from './actions';
+import ActionStatus from './actionStatus';
+
+export const fetchSongs = (artist) => {
+    return dispatch => {
+        dispatch(submitTerminalInputText(artist,[], ActionStatus.REQUESTING));
+        const stripped = encodeURIComponent(artist.trim())
+        return fetch(`https://api.spotify.com/v1/search?q=${stripped}&type=artist`)
+            .then(response => response.json())
+            .then(json => dispatch(submitTerminalInputText(artist, json.artists.items.map(artist => artist.name), ActionStatus.FINISHED)))
+    };
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -29,6 +29,7 @@ const lineStyle = {
     paddingTop: 0,
     paddingBottom: 0,
     paddingLeft: 0,
+    minHeight: 0,
 }
 
 const App = ({ params }) => (

--- a/src/components/TerminalLine.js
+++ b/src/components/TerminalLine.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, InputGroup, FormControl, Well } from 'react-bootstrap';
+import { Form, InputGroup, FormControl, Well, ListGroup, ListGroupItem } from 'react-bootstrap';
 
 const TerminalLine = ({ style, lineNumber, onChangeInputText, onSubmitInputText, isEditable, currentInputText, output }) => (
     <Form onSubmit={
@@ -7,14 +7,20 @@ const TerminalLine = ({ style, lineNumber, onChangeInputText, onSubmitInputText,
             e.preventDefault();
             onSubmitInputText(currentInputText);
         }}>
-            <InputGroup >
+            <InputGroup>
                 <InputGroup.Addon style={style}>$ {lineNumber}</InputGroup.Addon>
                 <FormControl style={style} type="text" disabled={!isEditable}
                     value={currentInputText}
                     onChange={onChangeInputText} autoFocus />
             </ InputGroup>
             { !isEditable &&
-                <Well style={style}>{output}</Well>
+            <Well style={style}>
+                <ListGroup>
+                    {output.map(
+                        artist => <ListGroupItem style={style}>{artist}</ListGroupItem>
+                    )}
+                </ListGroup>
+            </Well>
             }
     </Form>
 );

--- a/src/containers/VisibleTerminalView.js
+++ b/src/containers/VisibleTerminalView.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
-import { changeTerminalInputText, submitTerminalInputText } from '../actions/actions';
+import { changeTerminalInputText } from '../actions/actions';
+import { fetchSongs } from '../actions/asyncActions';
 import TerminalView from '../components/TerminalView';
 
 const mapStateToProps = (state, ownProps) => ({
@@ -11,7 +12,7 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = (dispatch) => ({
     onChangeInputText: (text) => dispatch(changeTerminalInputText(text)),
-    onSubmitInputText: (text) => dispatch(submitTerminalInputText(text)),
+    onSubmitInputText: (text) => dispatch(fetchSongs(text)),
 });
 
 const ViewableTerminalView = connect(

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, Route, browserHistory } from 'react-router';
-import { createStore } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunk from 'redux-thunk';
 import rootReducer from './reducers/root.js';
 //import devToolsEnhancer from 'remote-redux-devtools';
 import App from './components/App';
 
-let store = createStore(rootReducer, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__());
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+let store = createStore(rootReducer, composeEnhancers(applyMiddleware(thunk)));
 
 render(
     <Provider store={store}>

--- a/src/reducers/gui/terminal.js
+++ b/src/reducers/gui/terminal.js
@@ -1,10 +1,15 @@
 import ActionTypes from '../../actions/actionTypes';
+import ActionStatus from '../../actions/actionStatus';
 
 const output = (state="", action) => {
     switch(action.type) {
         case ActionTypes.SUBMIT_TERMINAL_INPUT_TEXT:
             //TODO: Evaluate here?
-            return "OUTPUT";
+            if (action.status === ActionStatus.FINISHED) {
+                return action.response;
+            } else {
+                return state;
+            }
         default:
             return state;
     }
@@ -32,10 +37,14 @@ const historyEntry = (state={
 const history = (state=[], action) => {
     switch(action.type) {
         case ActionTypes.SUBMIT_TERMINAL_INPUT_TEXT:
-            return [
-                ...state,
-                historyEntry(undefined, action),
-            ]
+            if (action.status === ActionStatus.FINISHED) {
+                return [
+                    ...state,
+                    historyEntry(undefined, action),
+                ]
+            } else {
+                return state;
+            }
         default:
             return state;
     
@@ -48,7 +57,11 @@ const currentInputText = (state="", action) => {
         case ActionTypes.CHANGE_TERMINAL_INPUT_TEXT:
             return action.text;
         case ActionTypes.SUBMIT_TERMINAL_INPUT_TEXT:
-            return "";
+            if (action.status === ActionStatus.FINISHED) {
+                return "";
+            } else {
+                return state;
+            }
         default:
             return state;
     }


### PR DESCRIPTION
Adds ability to make async requests using redux-thunk.

Demonstrates that async requests work by querying Spotify artists in the terminal
- when a user types a string into terminal and presses enter, the string is used to query
the spotify artists matching the query string.
- the results are displayed as a list below the query string
- Querying Spotify can be done using:
  - https://developer.spotify.com/web-api/search-item/